### PR TITLE
[#22664] Add check to bundles2dropbox.py to avoid uploading existing files

### DIFF
--- a/upload/bundles2dropbox.py
+++ b/upload/bundles2dropbox.py
@@ -38,20 +38,23 @@ def upload_files(basedir, client):
 
     """
     files = []
-
+    
+    folder_metadata = client.metadata('/')
+    metadata_set = {content['path'].split('/')[-1] for content in metadata['contents'] if content['is_dir'] == False}
+    
     for name in os.listdir(basedir):
         path = os.path.abspath(os.path.join(basedir, name))
-        if os.path.isfile(path) and valid_format(name, 'linux'):
+        if os.path.isfile(path) and valid_format(name, 'linux') and (name not in metadata_set):
             files.append(name)
 
     for name in os.listdir(basedir):
         path = os.path.abspath(os.path.join(basedir, name))
-        if os.path.isfile(path) and valid_format(name, 'windows'):
+        if os.path.isfile(path) and valid_format(name, 'windows') and (name not in metadata_set): 
             files.append(name)
 
     for name in os.listdir(basedir):
         path = os.path.abspath(os.path.join(basedir, name))
-        if os.path.isfile(path) and valid_format(name, 'osx'):
+        if os.path.isfile(path) and valid_format(name, 'osx') and (name not in metadata_set):
             files.append(name)
 
     for file in files:


### PR DESCRIPTION
Solves #22664 (Check for existing bundles in Dropbox and handle them accordingly) by querying Dropbox for list of existing files and populating a set. Each file is then cross-checked with the set to see if they exist already before uploading.